### PR TITLE
fix apriori algorithm aprioriGen

### DIFF
--- a/Ch11/apriori.py
+++ b/Ch11/apriori.py
@@ -41,8 +41,8 @@ def aprioriGen(Lk, k): #creates Ck
     lenLk = len(Lk)
     for i in range(lenLk):
         for j in range(i+1, lenLk): 
-            L1 = list(Lk[i])[:k-2]; L2 = list(Lk[j])[:k-2]
-            L1.sort(); L2.sort()
+            L1 = list(Lk[i]).sort()[:k-2]
+            L2 = list(Lk[j]).sort()[:k-2]
             if L1==L2: #if first k-2 elements are equal
                 retList.append(Lk[i] | Lk[j]) #set union
     return retList


### PR DESCRIPTION
When converting sets to lists, the ordering is non-deterministic.

For example if the input to aprioriGen was: ([{0,1}, {1,2}, {2,0}], 3)
If the lists stay in the same order as the sets appear, no two lists would have the same leading digit.

I think the optimisation only makes sense if you sort the lists first.