### PR TITLE
Update apriori.py

### DIFF
--- a/Ch11/apriori.py
+++ b/Ch11/apriori.py
@@ -66,10 +66,7 @@ def generateRules(L, supportData, minConf=0.7):  #supportData is a dict coming f
     for i in range(1, len(L)):#only get the sets with two or more items
         for freqSet in L[i]:
             H1 = [frozenset([item]) for item in freqSet]
-            if (i > 1):
-                rulesFromConseq(freqSet, H1, supportData, bigRuleList, minConf)
-            else:
-                calcConf(freqSet, H1, supportData, bigRuleList, minConf)
+            rulesFromConseq(freqSet, H1, supportData, bigRuleList, minConf)
     return bigRuleList         
 
 def calcConf(freqSet, H, supportData, brl, minConf=0.7):
@@ -84,6 +81,8 @@ def calcConf(freqSet, H, supportData, brl, minConf=0.7):
 
 def rulesFromConseq(freqSet, H, supportData, brl, minConf=0.7):
     m = len(H[0])
+    if m==1:
+        calcConf(freqSet,H,supportData,brl,minConf)
     if (len(freqSet) > (m + 1)): #try further merging
         Hmp1 = aprioriGen(H, m+1)#create Hm+1 new candidates
         Hmp1 = calcConf(freqSet, Hmp1, supportData, brl, minConf)


### PR DESCRIPTION
Fixed something about the confidence of a multi items(over 2) frequent set with one-item consequent won't be calculated in function generateRules(). Considerate the situation that a frequent lists L=[[{0},{1},{2}],[{0,1},{1,2},{0,2}],[{0,1,2}],[]], L[2][0]={0,1,2}. The index of this set is 2, which means it will run into the first branch(the rulesFromConseq one) in the original determine statements in line 69(if i>1:). And then in the original function rulesFromConseq(), m=1. So a m+1 items set will be calculated and the confidence of the set with m+1 item consequent was calculated. That is mean the confidence of a multi items(over 2) frequent set with one-item consequent won't be calculated.